### PR TITLE
Aseno/aid not found fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarJobDslExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarJobDslExtension.java
@@ -43,19 +43,19 @@ public class CodeSonarJobDslExtension extends ContextExtensionPoint {
     @RequiresPlugin(id = "codesonar", minimumVersion = "2.0.0")
     @DslExtensionMethod(context = PublisherContext.class)
     public Object codesonar(
-            String protocol, int socketTimeoutMS, String hubAddress, String projectName, String credentialId, String sslCertificateCredentialId, String visibilityFilter,
+            String protocol, int socketTimeoutMS, String hubAddress, String projectName, String credentialId, String sslCertificateCredentialId, String visibilityFilter, String codesonarProjectFile,
             Runnable closure
     ) {
         CodeSonarJobDslContext context = new CodeSonarJobDslContext();
         executeInContext(closure, context);
 
-        CodeSonarPublisher publisher = new CodeSonarPublisher(context.conditions, protocol, hubAddress, projectName, credentialId, visibilityFilter);
+        CodeSonarPublisher publisher = new CodeSonarPublisher(context.conditions, protocol, hubAddress, projectName, credentialId, visibilityFilter, codesonarProjectFile);
         publisher.setSocketTimeoutMS(socketTimeoutMS);
         publisher.setServerCertificateCredentialId(sslCertificateCredentialId);
         return publisher;
     }
 
-    public Object codesonar(String protocol, String hubAddress, String projectName, Runnable closure) {
-        return codesonar(protocol, -1, hubAddress, projectName, null, "", "2", closure);
+    public Object codesonar(String protocol, String hubAddress, String projectName, String codesonarProjectFile, Runnable closure) {
+        return codesonar(protocol, -1, hubAddress, projectName, null, "", "2", codesonarProjectFile, closure);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
@@ -236,19 +236,22 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
         analysisService = analysisServiceFactory.getAnalysisService(httpService, xmlSerializationService);
         analysisService.setVisibilityFilter(getVisibilityFilter());
 
+        String analysisId = null;
         if(StringUtils.isBlank(aid)) {
             LOGGER.log(Level.INFO, "[CodeSonar] Determining analysis id...");
-            aid = workspace.act(new DetermineAid());
+            analysisId = workspace.act(new DetermineAid());
+            LOGGER.log(Level.INFO, "[CodeSonar] Found analysis id: {0}", analysisId);
         } else {
+            analysisId = aid;
             LOGGER.log(Level.INFO, "[CodeSonar] Using override analysis id: '" + aid + "'.");
         }
         
-        String analysisUrl = baseHubUri.toString() + "/analysis/" + aid + ".xml";
+        String analysisUrl = baseHubUri.toString() + "/analysis/" + analysisId + ".xml";
 
         Analysis analysisWarnings = analysisService.getAnalysisFromUrlWarningsByFilter(analysisUrl);
-        URI metricsUri = metricsService.getMetricsUriFromAnAnalysisId(baseHubUri, aid);
+        URI metricsUri = metricsService.getMetricsUriFromAnAnalysisId(baseHubUri, analysisId);
         Metrics metrics = metricsService.getMetricsFromUri(metricsUri);
-        URI proceduresUri = proceduresService.getProceduresUriFromAnAnalysisId(baseHubUri, aid);
+        URI proceduresUri = proceduresService.getProceduresUriFromAnAnalysisId(baseHubUri, analysisId);
         Procedures procedures = proceduresService.getProceduresFromUri(proceduresUri);
 
         Analysis analysisNewWarnings = analysisService.getAnalysisFromUrlWithNewWarnings(analysisUrl);

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/config.jelly
@@ -10,11 +10,11 @@
        <f:textbox />
     </f:entry>
 
-    <f:entry field="hubAddress" title="Hub address">
+    <f:entry field="hubAddress" title="Hub Address">
         <f:textbox/>
     </f:entry>
     
-    <f:entry field="projectName" title="Project name">
+    <f:entry field="projectName" title="Project Name">
         <f:textbox default="$${JOB_NAME}" />
     </f:entry>
 
@@ -33,6 +33,10 @@
     <f:invisibleEntry field="aid" title="Analysis ID Override" >
         <f:textbox/>
     </f:invisibleEntry>
+    
+    <f:entry field="codesonarProjectFile" title="CodeSonar Project File">
+        <f:textbox/>
+    </f:entry>
 
     <f:section title="Configure build status conditions"> 
         <f:block>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/config.jelly
@@ -30,9 +30,9 @@
         <c:select/>
     </f:entry>
 
-    <f:entry field="aid" title="Analysis ID Override">
+    <f:invisibleEntry field="aid" title="Analysis ID Override" >
         <f:textbox/>
-    </f:entry>
+    </f:invisibleEntry>
 
     <f:section title="Configure build status conditions"> 
         <f:block>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-aid.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-aid.html
@@ -1,1 +1,4 @@
-<div>Use this attribute to override analysis id</div>
+<div>
+    Use this attribute to override analysis id.<br/>
+    NOTE: This attribute must never be used with Jenkins' freestyle pipeline projects, it is meant to be used only within a Jenkinsfile on a CI/CD pipeline.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-codesonarProjectFile.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-codesonarProjectFile.html
@@ -1,0 +1,1 @@
+<div>The project file as defined by CodeSonar.</div>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-credentialId.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-credentialId.html
@@ -1,1 +1,1 @@
-<div>CodeSonar credentials</div>
+<div>The hub user account credentials, they can be provided with a Jenkins Credential parameter of type <i>Username with password</i>, or with a Credential parameter of type of type <i>Certificate</i>, specified in the PKCS#12 format.</div>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-hubAddress.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-hubAddress.html
@@ -1,1 +1,1 @@
-<div>IP address of the CodeSonar hub</div>
+<div>Your hub location as <i>host:port</i> without protocol. For example, <code>myhub.example.com:7340</code></div>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-projectName.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-projectName.html
@@ -1,1 +1,1 @@
-<div>The name of the project. All characters allowed</div>
+<div>The name of the Jenkins project. All characters allowed</div>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-serverCertificateCredentialId.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-serverCertificateCredentialId.html
@@ -1,1 +1,1 @@
-<div>Jenkins Credentials containing HTTPS Server certificate of CodeSonar Hub. Credentials must be of type <i>Secret File</i> and must include a X509 certificate.</div>
+<div>[HTTPS hubs only] If your hub uses a self-signed server certificate, it contains a copy of this certificate so that the plugin can be instructed to trust it. The certificate must be expressed as Credential parameter of type <i>Secret File</i> and must include a X509 certificate.</div>

--- a/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-visibilityFilter.html
+++ b/src/main/resources/org/jenkinsci/plugins/codesonar/CodeSonarPublisher/help-visibilityFilter.html
@@ -1,7 +1,15 @@
 <div>
-    The visibility filter is used to filter which warnings that are used for the conditions.
-    It matches the items under "Visible Warnings" under an analysis in CodeSonar.
-
-    Please use the ID number of the filter you want to use. You can find the ID numbers under
-    this url <b>hub_address</b>/savedsearches.html?filter=3&ssdomain=0&ssearchsgrd=Ay_0D_BTl3BTl3AgBg
+    <p dir="auto">The CodeSonar warning visibility filter allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in new warnings (that is, those that were issued for the first time in the current analysis).</p>
+    <ul dir="auto">
+        <li>
+        <p dir="auto">You can specify a warning visibility filter by <em>name</em> or by numeric <em>ID</em>.</p>
+        </li>
+        <li>
+        <p dir="auto">The available warning visibility filters for a given hub user account are those for which the account has <code>NAMEDSEARCH_READ</code> permission. The exception is the <strong>all</strong> filter, which is always available to all users.</p>
+        </li>
+        <li>
+        <p dir="auto">To view the list of available warning visibility filters, including their names, IDs, and search definitions, see the <strong>Warnings</strong> tab of the <strong>Saved Searches</strong> page in the CodeSonar GUI.</p>
+        <p dir="auto"><strong>MANUAL</strong>: Using CodeSonar &gt; GUI Reference &gt; Searching &gt; GUI: Saved Searches</p>
+        </li>
+    </ul>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/codesonar/integration/CodeSonarPublisherIT.java
+++ b/src/test/java/org/jenkinsci/plugins/codesonar/integration/CodeSonarPublisherIT.java
@@ -1,16 +1,11 @@
 package org.jenkinsci.plugins.codesonar.integration;
 
-import hudson.model.Cause;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.Result;
-import hudson.model.queue.QueueTaskFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.codesonar.CodeSonarPublisher;
@@ -23,6 +18,12 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 
 /**
  *
@@ -46,11 +47,12 @@ public class CodeSonarPublisherIT {
 
         final String EMPTY_HUB_ADDRESS = "";
         final String VALID_PROJECT_NAME = "projectName";
+        final String VALID_CODESONAR_PROJECT_FILE = "projectName.prj";
 
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
 
         List<Condition> conditions = new ArrayList<>();
-        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", EMPTY_HUB_ADDRESS, VALID_PROJECT_NAME, "", "2");
+        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", EMPTY_HUB_ADDRESS, VALID_PROJECT_NAME, "", "2", VALID_CODESONAR_PROJECT_FILE);
         project.getPublishersList().add(codeSonarPublisher);
 
         // act
@@ -73,11 +75,12 @@ public class CodeSonarPublisherIT {
         
         final String VALID_HUB_ADDRESS = "10.10.10.10";
         final String EMPTY_PROJECT_NAME = "";
+        final String VALID_CODESONAR_PROJECT_FILE = "projectName.prj";
 
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
         
         List<Condition> conditions = new ArrayList<>();
-        project.getPublishersList().add(new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS, EMPTY_PROJECT_NAME,"", "2"));
+        project.getPublishersList().add(new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS, EMPTY_PROJECT_NAME,"", "2", VALID_CODESONAR_PROJECT_FILE));
         
         // act
         QueueTaskFuture<FreeStyleBuild> queueTaskFuture = project.scheduleBuild2(0, new Cause.UserIdCause());

--- a/src/test/java/org/jenkinsci/plugins/codesonar/integration/conditions/ConditionIntegrationTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/codesonar/integration/conditions/ConditionIntegrationTestBase.java
@@ -1,8 +1,13 @@
 package org.jenkinsci.plugins.codesonar.integration.conditions;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jenkinsci.plugins.codesonar.AnalysisServiceFactory;
 import org.jenkinsci.plugins.codesonar.models.analysis.Analysis;
 import org.jenkinsci.plugins.codesonar.models.analysis.Warning;
@@ -17,9 +22,6 @@ import org.jenkinsci.plugins.codesonar.services.ProceduresService;
 import org.jenkinsci.plugins.codesonar.services.XmlSerializationService;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  *
@@ -40,6 +42,7 @@ public abstract class ConditionIntegrationTestBase {
     
     protected final URI VALID_HUB_ADDRESS = URI.create("10.10.10.10");
     protected final String VALID_PROJECT_NAME = "projectName";
+    protected final String VALID_CODESONAR_PROJECT_FILE = "projectName.prj";
 
     public void setUp() throws Exception {
         mockedAnalysisService = mock(AnalysisService.class);

--- a/src/test/java/org/jenkinsci/plugins/codesonar/integration/conditions/NewWarningsIncreasedByPercentageConditionIT.java
+++ b/src/test/java/org/jenkinsci/plugins/codesonar/integration/conditions/NewWarningsIncreasedByPercentageConditionIT.java
@@ -1,17 +1,19 @@
 package org.jenkinsci.plugins.codesonar.integration.conditions;
 
-import hudson.model.Cause;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.Result;
-import hudson.model.queue.QueueTaskFuture;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jenkinsci.plugins.codesonar.CodeSonarPublisher;
 import org.jenkinsci.plugins.codesonar.conditions.Condition;
 import org.jenkinsci.plugins.codesonar.conditions.NewWarningsIncreasedByPercentageCondition;
 import org.junit.Assert;
 import org.junit.Test;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 
 public class NewWarningsIncreasedByPercentageConditionIT extends ConditionIntegrationTestBase {
 
@@ -32,7 +34,7 @@ public class NewWarningsIncreasedByPercentageConditionIT extends ConditionIntegr
         List<Condition> conditions = new ArrayList<>();
         conditions.add(condition);
 
-        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", "2");
+        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", "2", VALID_CODESONAR_PROJECT_FILE);
         codeSonarPublisher.setAnalysisService(mockedAnalysisService);
         codeSonarPublisher.setMetricsService(mockedMetricsService);
         codeSonarPublisher.setProceduresService(mockedProceduresService);
@@ -64,8 +66,7 @@ public class NewWarningsIncreasedByPercentageConditionIT extends ConditionIntegr
         List<Condition> conditions = new ArrayList<>();
         conditions.add(condition);
 
-        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(
-                conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", this.VISIBILITY_FILTER);
+        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", this.VISIBILITY_FILTER, VALID_CODESONAR_PROJECT_FILE);
         codeSonarPublisher.setAnalysisService(mockedAnalysisService);
         codeSonarPublisher.setMetricsService(mockedMetricsService);
         codeSonarPublisher.setProceduresService(mockedProceduresService);

--- a/src/test/java/org/jenkinsci/plugins/codesonar/integration/conditions/WarningCountIncreaseSpecifiedScoreAndHigherConditionIT.java
+++ b/src/test/java/org/jenkinsci/plugins/codesonar/integration/conditions/WarningCountIncreaseSpecifiedScoreAndHigherConditionIT.java
@@ -1,17 +1,19 @@
 package org.jenkinsci.plugins.codesonar.integration.conditions;
 
-import hudson.model.Cause;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.Result;
-import hudson.model.queue.QueueTaskFuture;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jenkinsci.plugins.codesonar.CodeSonarPublisher;
 import org.jenkinsci.plugins.codesonar.conditions.Condition;
 import org.jenkinsci.plugins.codesonar.conditions.WarningCountIncreaseSpecifiedScoreAndHigherCondition;
 import org.junit.Assert;
 import org.junit.Test;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 
 /**
  *
@@ -36,7 +38,7 @@ public class WarningCountIncreaseSpecifiedScoreAndHigherConditionIT extends Cond
         List<Condition> conditions = new ArrayList<>();
         conditions.add(condition);
 
-        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", "2");
+        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", "2", VALID_CODESONAR_PROJECT_FILE);
         codeSonarPublisher.setAnalysisService(mockedAnalysisService);
         codeSonarPublisher.setMetricsService(mockedMetricsService);
         codeSonarPublisher.setProceduresService(mockedProceduresService);
@@ -69,7 +71,7 @@ public class WarningCountIncreaseSpecifiedScoreAndHigherConditionIT extends Cond
         List<Condition> conditions = new ArrayList<>();
         conditions.add(condition);
 
-        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", "2");
+        CodeSonarPublisher codeSonarPublisher = new CodeSonarPublisher(conditions, "http", VALID_HUB_ADDRESS.toString(), VALID_PROJECT_NAME, "", "2", VALID_CODESONAR_PROJECT_FILE);
         codeSonarPublisher.setAnalysisService(mockedAnalysisService);
         codeSonarPublisher.setMetricsService(mockedMetricsService);
         codeSonarPublisher.setProceduresService(mockedProceduresService);


### PR DESCRIPTION
Contains the following set of improvements:

1. Fix bug where analysis ID project config parameter is incorrectly set and made constant after first successful analysis.
1. Add a “codesonarProjectFile” parameter to the plugin so that the user can tell the plugin where to find their CodeSonar prj_files directory.
1. Update interactive help content to make it clear that the “projectName” parameter is a Jenkins project name (not a CodeSonar project name).