### PR TITLE
Build on container agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 8]
+])


### PR DESCRIPTION
Container agents are usually faster to provision and generate less cost for the project.

`recommendedConfigurations ` does no longer do anything.