### PR TITLE
Fix github workflow broken by actions/cache@v1.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,22 +4,26 @@ on:
   push:
     branches:
       - master
+      - gtmaster
   pull_request:
     branches:
       - master
+      - gtmaster
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 12, 13 ]
+        java:
+          - 17
+          - 21
     name: Java ${{ matrix.java }} compile
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Cache maven dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-maven-dependencies
         with:
@@ -29,8 +33,9 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: ${{ matrix.java }}
 
       - run: mvn test spotbugs:check

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 8]
+    [platform: 'linux', jdk: 11]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,18 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
             <version>2.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <version>2.5.3</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -159,13 +166,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>
@@ -177,13 +184,19 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.9-1</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10</version>
+            <version>2.13.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>2.38.0</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/codesonar/models/json/SearchConfigData.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/models/json/SearchConfigData.java
@@ -12,11 +12,11 @@ import org.javatuples.Pair;
 public class SearchConfigData {
     public enum SortingOrder {ASCENDING, DESCENDING}
     
-    public boolean count;
-    public int offset;
-    public int limit;
-    public List<Pair<String, String>> orderBy;
-    public List<String> columns;
+    private boolean count;
+    private int offset;
+    private int limit;
+    private List<Pair<String, String>> orderBy;
+    private List<String> columns;
     
     public SearchConfigData() {
         this.count = false;


### PR DESCRIPTION
- Use newer actions/cache since v1 has been retracted.
- Use actions/checkout v4 instead of 'master'.
- Use actions/setup-java v2 and explicitly specify java distribution.
- Test on Java 17 and 21.
- Run pipeline on gtmaster branch.