### PR TITLE
Require Jenkins core 2.492.3 and Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
+/*
+ * See the documentation for more options:
+ * https://github.com/jenkins-infra/pipeline-library/
+ */
 buildPlugin(
-  useContainerAgent: true,
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 11]
+    [platform: 'linux', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.16</version>
         <relativePath />
     </parent>
 
@@ -15,9 +15,9 @@
 
     <properties>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.462</jenkins.baseline>
+        <jenkins.baseline>2.492</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-        <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+        <jenkins-test-harness.version>2444.v82e008e25040</jenkins-test-harness.version>
     </properties>
     
     <contributors>
@@ -55,14 +55,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>4228.v0a_71308d905b_</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-weekly</artifactId>
-                <version>4488.v7fe26526366e</version>
+                <version>4740.v75a_90f6fefb_7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -184,7 +177,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
-            <version>2.3.9-1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
See PR #16.  Upgrade to Java 17 and Jenkins 2.479.x.

This new PR fixes some merge conflicts in PR #16.