### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarBuildAction.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.javatuples.Pair;
 import org.jenkinsci.plugins.codesonar.models.CodeSonarBuildActionDTO;
 import org.jenkinsci.plugins.codesonar.models.analysis.Analysis;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import org.apache.commons.collections.ListUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.javatuples.Pair;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.codesonar.conditions.Condition;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/Condition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/Condition.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.codesonar.conditions;
 
 import java.text.MessageFormat;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.codesonar.CodeSonarLogger;
 import org.jenkinsci.plugins.codesonar.CodeSonarPluginException;
 import org.jenkinsci.plugins.codesonar.services.CodeSonarHubAnalysisDataLoader;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/NewWarningsIncreasedByPercentageCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/NewWarningsIncreasedByPercentageCondition.java
@@ -5,7 +5,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.codesonar.CodeSonarLogger;
 import org.jenkinsci.plugins.codesonar.CodeSonarPluginException;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseOverallCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseOverallCondition.java
@@ -5,7 +5,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.codesonar.CodeSonarLogger;
 import org.jenkinsci.plugins.codesonar.CodeSonarPluginException;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseSpecifiedScoreAndHigherCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseSpecifiedScoreAndHigherCondition.java
@@ -4,7 +4,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.codesonar.CodeSonarLogger;
 import org.jenkinsci.plugins.codesonar.CodeSonarPluginException;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/AnalysisService.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/AnalysisService.java
@@ -14,7 +14,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.jenkinsci.plugins.codesonar.CodeSonarHubCommunicationException;
 import org.jenkinsci.plugins.codesonar.CodeSonarJsonSyntaxException;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/HubInfoService.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/HubInfoService.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.fluent.Request;
 import org.jenkinsci.plugins.codesonar.CodeSonarHubCommunicationException;
 import org.jenkinsci.plugins.codesonar.CodeSonarJsonSyntaxException;

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/Utils.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.codesonar.services;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class Utils {
     

--- a/src/test/java/org/jenkinsci/plugins/codesonar/integration/CodeSonarPublisherIT.java
+++ b/src/test/java/org/jenkinsci/plugins/codesonar/integration/CodeSonarPublisherIT.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.codesonar.CodeSonarLogger;
 import org.jenkinsci.plugins.codesonar.CodeSonarPublisher;
 import org.jenkinsci.plugins.codesonar.conditions.Condition;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- Renamed the `org.apache.commons.lang.*` imports to `org.apache.commons.lang3.*` and declared
  `io.jenkins.plugins:commons-lang3-api` (`NumberUtils.isNumber` and `StringUtils.strip` have no
  clean JDK equivalent).

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer. I tried the bump from `5.18`, but the
newer parent's generated `InjectedTest` then fails to compile (`package org.jvnet.hudson.test.injected
does not exist`) — an unrelated harness change, so I left the parent alone.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
